### PR TITLE
Fix loading screen style

### DIFF
--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -21,8 +21,8 @@ const Loading = () => {
               </IonCol>
             </IonRow>
             <IonRow>
-              <IonCol class="ion-padding-top">
-                <IonText class="ion-text-center">
+              <IonCol className="pt-5">
+                <IonText className="text-center">
                   <p>Loading...</p>
                 </IonText>
               </IonCol>


### PR DESCRIPTION
The `ion` styles did not apply so I used tailwind classes.