### PR TITLE
add streak to global store

### DIFF
--- a/src/pages/Failure.tsx
+++ b/src/pages/Failure.tsx
@@ -25,6 +25,7 @@ const Failure = () => {
     guess,
     addPoints,
     setPointDifference,
+    resetStreak,
   } = useStore()
 
   const [animReady, setAnimReady] = useState(false)
@@ -45,6 +46,7 @@ const Failure = () => {
   const updateScores = () => {
     // set the points here, as we wanted to animate the difference
     addPoints(pointDifference)
+    resetStreak()
     // reset point difference for next round
     setPointDifference(0)
   }

--- a/src/pages/GameOver.tsx
+++ b/src/pages/GameOver.tsx
@@ -1,20 +1,20 @@
-import React, { useRef, useState } from 'react'
 import {
-  IonPage,
-  IonContent,
   IonButton,
+  IonContent,
+  IonPage,
   useIonViewDidEnter,
   useIonViewWillLeave,
 } from '@ionic/react'
-import { animated, config, useChain, useSpring } from 'react-spring'
-import { useHistory } from 'react-router'
-import useStore from '../useStore'
-
 import emoji from 'node-emoji'
+import React, { useRef, useState } from 'react'
+import { useHistory } from 'react-router'
+import { animated, config, useChain, useSpring } from 'react-spring'
+
+import useStore from '../useStore'
 
 const GameOver = () => {
   const history = useHistory()
-  const { points, resetState } = useStore()
+  const { points, resetState, bestStreak } = useStore()
 
   const [animReady, setAnimReady] = useState(false)
 
@@ -89,10 +89,13 @@ const GameOver = () => {
 
         <animated.div style={textAnimProps}>
           <p>Points</p>
+          <div className="text-gray-500 mt-4 text-xl font-bold">
+            best streak: {bestStreak}
+          </div>
         </animated.div>
 
         <animated.div style={buttonAnimProps}>
-          <IonButton className="mt-16" onClick={navigateNext}>
+          <IonButton className="mt-12" onClick={navigateNext}>
             Start again
           </IonButton>
         </animated.div>

--- a/src/pages/Success.tsx
+++ b/src/pages/Success.tsx
@@ -25,12 +25,16 @@ const Success = () => {
     setPointDifference,
     lives,
     livesTotal,
+    increaseStreak,
+    streak,
   } = useStore()
 
   const [animReady, setAnimReady] = useState(false)
 
   // these two lifecycle hooks make sure the animations run everytime the page is loaded
   useIonViewDidEnter(() => {
+    // increase streak by 1
+    increaseStreak()
     setAnimReady(true)
   })
   useIonViewWillLeave(() => {
@@ -94,7 +98,8 @@ const Success = () => {
   return (
     <IonPage>
       <IonContent className="text-center">
-        <h1 className="mt-16 text-2xl font-extrabold">Correct Guess</h1>
+        <h1 className="mt-12 text-2xl font-extrabold">Correct Guess</h1>
+        <div>{streak} in a row</div>
         <animated.div style={emojiAnimProps}>
           <p
             style={{ fontFamily: 'Twitter Color Emoji' }}

--- a/src/useStore.ts
+++ b/src/useStore.ts
@@ -30,6 +30,7 @@ interface Store {
   timeRemaining: number
   movie: Movie
   streak: number
+  bestStreak: number
   guess: Guess
   setState: (state: Partial<Store>) => void
   resetState: () => void
@@ -76,6 +77,7 @@ const initialState: Partial<Store> = {
   pointDifference: 0, // the points gained or lost since the last question
   timeRemaining: QUESTION_TIME,
   streak: 0,
+  bestStreak: 0,
   movie: {
     imdbId: '',
     title: '',
@@ -148,6 +150,9 @@ const [useStore] = create<Store>(
       increaseStreak() {
         set((state: Store) => {
           state.streak++
+          if (state.streak > state.bestStreak) {
+            state.bestStreak = state.streak
+          }
         })
       },
 

--- a/src/useStore.ts
+++ b/src/useStore.ts
@@ -29,6 +29,7 @@ interface Store {
   pointDifference: number
   timeRemaining: number
   movie: Movie
+  streak: number
   guess: Guess
   setState: (state: Partial<Store>) => void
   resetState: () => void
@@ -38,6 +39,8 @@ interface Store {
   addPoints: (points: number) => void
   setPointDifference: (pointDifference: number) => void
   removeLife: () => void
+  increaseStreak: () => void
+  resetStreak: () => void
 }
 
 // setup immer to ensure data is changed immutably
@@ -72,6 +75,7 @@ const initialState: Partial<Store> = {
   points: 0,
   pointDifference: 0, // the points gained or lost since the last question
   timeRemaining: QUESTION_TIME,
+  streak: 0,
   movie: {
     imdbId: '',
     title: '',
@@ -138,6 +142,18 @@ const [useStore] = create<Store>(
             state.lives = 0
             state.alive = false
           }
+        })
+      },
+
+      increaseStreak() {
+        set((state: Store) => {
+          state.streak++
+        })
+      },
+
+      resetStreak() {
+        set((state: Store) => {
+          state.streak = 0
         })
       },
     })),


### PR DESCRIPTION
### Description

This PR adds tracking of streak data.

A streak is a sequence of correctly answered questions. Answering a bonus question correctly does not increase the streak.

The current streak is displayed whenever the Success screen is shown. The best streak is then shown to the user once the game has ended on the Game Over screen.
![image](https://user-images.githubusercontent.com/22471485/80456655-46599b80-892e-11ea-9f70-bb602e6acf7c.png)

![image](https://user-images.githubusercontent.com/22471485/80456783-7a34c100-892e-11ea-9e18-d557e2d47571.png)

### Related Issues

#114 

### Checklist

- [x] Have you added tests where necessary? Do all the test pass? 
- [x] Have you added descriptive comments to your code?
- [x] Have you updated the documentation related to this propo
