### PR TITLE
122 extend trivia screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12016,6 +12016,14 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
       "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
     },
+    "react-number-format": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-4.4.1.tgz",
+      "integrity": "sha512-ZGFMXZ0U7DcmQ3bSZY3FULOA1mfqreT9NIMYZNoa/ouiSgiTQiYA95Uj2KN8ge6BRr+ghA5vraozqWqsHZQw3Q==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-router": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "ramda": "0.27.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
+    "react-number-format": "4.4.1",
     "react-router": "5.1.2",
     "react-router-dom": "5.1.2",
     "react-router-last-location": "2.0.1",

--- a/src/components/TriviaOverlay.tsx
+++ b/src/components/TriviaOverlay.tsx
@@ -12,7 +12,7 @@ const TriviaOverlay = ({ children, className, margin, style }: Props) => {
     <div
       className={`absolute flex rounded-md ${className}`}
       style={{
-        background: 'rgba(196, 196, 196, 0.75)',
+        background: 'rgba(255, 255, 255, 0.85)',
         border: '1px solid #B7B7B7',
         boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.25)',
         width: `calc(100% - 2 * ${margin})`,

--- a/src/pages/Failure.tsx
+++ b/src/pages/Failure.tsx
@@ -150,7 +150,7 @@ const Failure = () => {
             <div className="font-light text-2xl mb-2">{movie.title}</div>
           </div>
           <div className="w-32 mx-auto">
-            <img className="rounded" src={movie.posterUrl} alt={movie.title} />
+            <img className="rounded" src={movie.posterPath} alt={movie.title} />
           </div>
         </animated.div>
       </IonContent>

--- a/src/pages/Poster.tsx
+++ b/src/pages/Poster.tsx
@@ -64,14 +64,6 @@ const Poster = () => {
     const budget = data?.movie.budget
     const popularity = data?.movie.popularity
     const revenue = data?.movie.revenue
-    console.log({
-      imdbId,
-      title,
-      posterPath,
-      budget,
-      popularity,
-      revenue,
-    })
     if (imdbId && title && posterPath && budget && popularity && revenue) {
       setMovie({
         imdbId,

--- a/src/pages/Poster.tsx
+++ b/src/pages/Poster.tsx
@@ -16,14 +16,7 @@ import StatsLayout from '../components/layouts/StatsLayout'
 import Loading from '../components/Loading'
 import Timer from '../components/Timer'
 import { QUESTION_TIME } from '../settings'
-import useStore from '../useStore'
-
-interface Movie {
-  imdbId: string
-  title: string
-  releaseYear: number
-  posterPath: string
-}
+import useStore, { Movie } from '../useStore'
 
 interface RandomMovieData {
   movie: Movie
@@ -36,6 +29,9 @@ const RANDOM_MOVIE = gql`
       title
       releaseYear
       posterPath
+      budget
+      popularity
+      revenue
       randomMovies(num: 3, differentReleaseYear: true) {
         imdbId
         title
@@ -64,12 +60,26 @@ const Poster = () => {
   useEffect(() => {
     const imdbId = data?.movie.imdbId
     const title = data?.movie.title
-    const posterUrl = data?.movie.posterPath
-    if (imdbId && title && posterUrl) {
+    const posterPath = data?.movie.posterPath
+    const budget = data?.movie.budget
+    const popularity = data?.movie.popularity
+    const revenue = data?.movie.revenue
+    console.log({
+      imdbId,
+      title,
+      posterPath,
+      budget,
+      popularity,
+      revenue,
+    })
+    if (imdbId && title && posterPath && budget && popularity && revenue) {
       setMovie({
         imdbId,
         title,
-        posterUrl,
+        posterPath,
+        budget,
+        popularity,
+        revenue,
       })
     }
   }, [data])

--- a/src/pages/Question.tsx
+++ b/src/pages/Question.tsx
@@ -14,6 +14,9 @@ interface Movie {
   title: string
   releaseYear: number
   posterPath: string
+  budget?: number
+  revenue?: number
+  popularity?: number
   randomMovies: Movie[]
 }
 

--- a/src/pages/Question.tsx
+++ b/src/pages/Question.tsx
@@ -98,14 +98,14 @@ const Question = () => {
   const makeGuess = (
     guessedTitle: string,
     imdbId: string,
-    posterUrl: string,
+    posterPath: string,
   ) => {
     // store guess details in global store
-    if (imdbId && guessedTitle && posterUrl) {
+    if (imdbId && guessedTitle && posterPath) {
       setGuess({
         imdbId: imdbId,
         title: guessedTitle,
-        posterUrl: posterUrl,
+        posterPath: posterPath,
       })
     }
 

--- a/src/pages/Trivia.tsx
+++ b/src/pages/Trivia.tsx
@@ -1,41 +1,59 @@
-import { useQuery } from '@apollo/client'
-import { IonButton, IonContent, IonImg, IonPage } from '@ionic/react'
+import { useQuery, gql } from '@apollo/client'
+import { IonButton, IonContent, IonImg, IonPage, IonCard } from '@ionic/react'
 import React from 'react'
 import { useHistory } from 'react-router'
 
 import Loading from '../components/Loading'
 import TriviaOverlay from '../components/TriviaOverlay'
-import { MovieData, MOVIES } from './Question'
+import { MovieData } from './Question'
+
+export const GET_MOVIE = gql`
+  query($imdbId: String!) {
+    movie(imdbId: $imdbId) {
+      imdbId
+      title
+      releaseYear
+      posterPath
+      revenue
+      popularity
+      budget
+    }
+  }
+`
 
 const Trivia = () => {
   const history = useHistory()
 
-  const { loading, data } = useQuery<MovieData>(MOVIES, {
-    fetchPolicy: 'cache-only',
+  const { loading, data } = useQuery<MovieData>(GET_MOVIE, {
+    // fetchPolicy: 'cache-only',
+    variables: { imdbId: 'tt0167261' },
   })
 
   const navigateNext = () => history.push('/poster')
 
-  const overlayMargin = '5%'
+  const overlayMargin = '3%'
 
   if (loading || !data) return <Loading />
 
   return (
     <IonPage>
       <IonContent>
-        <div className="m-3 flex flex-col items-center">
-          <div className="w-full relative">
-            <IonImg src={data?.movie?.posterPath} className="w-full h-full" />
+        <div className="flex flex-col items-center">
+          <div className="p-4 w-full relative">
+            <IonCard>
+              <IonImg src={data?.movie?.posterPath} className="w-full h-full" />
+            </IonCard>
 
             <TriviaOverlay
-              className="items-center justify-center font-bold text-black text-2xl"
+              className="items-center justify-center "
               margin={overlayMargin}
               style={{
                 top: overlayMargin,
                 height: '50px',
+                backgroundColor: 'white',
               }}
             >
-              <span>Did you know that?</span>
+              <span className="text-2xl text-black">Did you know that...</span>
             </TriviaOverlay>
 
             <TriviaOverlay
@@ -44,13 +62,26 @@ const Trivia = () => {
               style={{
                 top: `calc(${overlayMargin} + 20%)`,
                 color: 'black',
-                fontWeight: 'bold',
                 padding: '10px',
               }}
             >
               <div>
-                <p>Title: {data?.movie?.title}</p>
-                <p>Release Year: {data?.movie?.releaseYear}</p>
+                <p>
+                  <span className="font-bold">...{data?.movie?.title}</span> was
+                  released in
+                  <span className="font-bold">
+                    {' '}
+                    {data?.movie?.releaseYear}
+                  </span>{' '}
+                  and earned around{' '}
+                  <span className="font-bold">${data?.movie?.revenue}</span> at
+                  the box office with a budget of{' '}
+                  <span className="font-bold">${data?.movie?.budget}</span>.
+                  <p className="mt-4">
+                    Popularity:{' '}
+                    <span className="font-bold">{data?.movie?.popularity}</span>
+                  </p>
+                </p>
               </div>
             </TriviaOverlay>
           </div>

--- a/src/pages/Trivia.tsx
+++ b/src/pages/Trivia.tsx
@@ -15,7 +15,6 @@ import { animated, useChain, useSpring } from 'react-spring'
 
 import Loading from '../components/Loading'
 import TriviaOverlay from '../components/TriviaOverlay'
-import useStore from '../useStore'
 import { MovieData } from './Question'
 
 export const MOVIES = gql`

--- a/src/pages/Trivia.tsx
+++ b/src/pages/Trivia.tsx
@@ -1,15 +1,26 @@
-import { useQuery, gql } from '@apollo/client'
-import { IonButton, IonContent, IonImg, IonPage, IonCard } from '@ionic/react'
-import React from 'react'
+import { gql, useQuery } from '@apollo/client'
+import {
+  IonButton,
+  IonCard,
+  IonContent,
+  IonImg,
+  IonPage,
+  useIonViewDidEnter,
+  useIonViewWillLeave,
+} from '@ionic/react'
+import React, { useRef, useState } from 'react'
+import NumberFormat from 'react-number-format'
 import { useHistory } from 'react-router'
+import { animated, useChain, useSpring } from 'react-spring'
 
 import Loading from '../components/Loading'
 import TriviaOverlay from '../components/TriviaOverlay'
+import useStore from '../useStore'
 import { MovieData } from './Question'
 
-export const GET_MOVIE = gql`
-  query($imdbId: String!) {
-    movie(imdbId: $imdbId) {
+export const MOVIES = gql`
+  {
+    movie {
       imdbId
       title
       releaseYear
@@ -23,15 +34,39 @@ export const GET_MOVIE = gql`
 
 const Trivia = () => {
   const history = useHistory()
+  const [animReady, setAnimReady] = useState(false)
 
-  const { loading, data } = useQuery<MovieData>(GET_MOVIE, {
-    // fetchPolicy: 'cache-only',
-    variables: { imdbId: 'tt0167261' },
+  // these two lifecycle hooks make sure the animations run everytime the page is loaded
+  useIonViewDidEnter(() => {
+    setAnimReady(true)
+  })
+  useIonViewWillLeave(() => {
+    setAnimReady(false)
+  })
+
+  const { loading, data } = useQuery<MovieData>(MOVIES, {
+    fetchPolicy: 'cache-only',
   })
 
   const navigateNext = () => history.push('/poster')
 
   const overlayMargin = '3%'
+
+  const animationPropsRef = useRef<any>()
+  const animationProps = useSpring({
+    ref: animationPropsRef,
+    transform: !animReady ? 'translate(0, 1000px)' : 'translate(0, -440px)',
+    opacity: !animReady ? 0 : 1,
+  })
+
+  const appearAnimRef = useRef<any>()
+  const appearAnimProps = useSpring({
+    ref: appearAnimRef,
+    opacity: !animReady ? 0 : 1,
+  })
+
+  // specify order of animations, will be animated one after the other
+  useChain([animationPropsRef, appearAnimRef])
 
   if (loading || !data) return <Loading />
 
@@ -39,8 +74,8 @@ const Trivia = () => {
     <IonPage>
       <IonContent>
         <div className="flex flex-col items-center">
-          <div className="p-4 w-full relative">
-            <IonCard>
+          <div className="p-2 w-full relative">
+            <IonCard className="pt-8">
               <IonImg src={data?.movie?.posterPath} className="w-full h-full" />
             </IonCard>
 
@@ -53,44 +88,71 @@ const Trivia = () => {
                 backgroundColor: 'white',
               }}
             >
-              <span className="text-2xl text-black">Did you know that...</span>
+              <span className="text-2xl text-black font-light">
+                Did you know that...
+              </span>
             </TriviaOverlay>
 
-            <TriviaOverlay
-              className="flex-col text-lg"
-              margin={overlayMargin}
-              style={{
-                top: `calc(${overlayMargin} + 20%)`,
-                color: 'black',
-                padding: '10px',
-              }}
-            >
-              <div>
-                <p>
-                  <span className="font-bold">...{data?.movie?.title}</span> was
-                  released in
-                  <span className="font-bold">
-                    {' '}
-                    {data?.movie?.releaseYear}
-                  </span>{' '}
-                  and earned around{' '}
-                  <span className="font-bold">${data?.movie?.revenue}</span> at
-                  the box office with a budget of{' '}
-                  <span className="font-bold">${data?.movie?.budget}</span>.
-                  <p className="mt-4">
-                    Popularity:{' '}
-                    <span className="font-bold">{data?.movie?.popularity}</span>
-                  </p>
-                </p>
-              </div>
-            </TriviaOverlay>
+            <animated.div style={animationProps}>
+              <TriviaOverlay
+                className="flex-col text-lg"
+                margin={overlayMargin}
+                style={{
+                  top: `calc(${overlayMargin} + 20%)`,
+                  color: 'black',
+                  padding: '10px',
+                }}
+              >
+                <div className="font-light">
+                  <div>
+                    ...
+                    <span className="font-semibold">
+                      {data?.movie?.title}
+                    </span>{' '}
+                    was released in
+                    <span className="font-bold">
+                      {' '}
+                      {data?.movie?.releaseYear}
+                    </span>{' '}
+                    and earned around{' '}
+                    <span className="font-bold">
+                      <NumberFormat
+                        value={data?.movie?.revenue}
+                        displayType={'text'}
+                        thousandSeparator={true}
+                        prefix={'$'}
+                      />
+                    </span>{' '}
+                    at the box office with a budget of{' '}
+                    <span className="font-bold">
+                      <NumberFormat
+                        value={data?.movie?.budget}
+                        displayType={'text'}
+                        thousandSeparator={true}
+                        prefix={'$'}
+                      />
+                    </span>
+                    .
+                    <p className="mt-4">
+                      Popularity:{' '}
+                      <span className="font-bold">
+                        {data?.movie?.popularity?.toFixed(1)}
+                      </span>
+                    </p>
+                  </div>
+                </div>
+              </TriviaOverlay>
+            </animated.div>
           </div>
 
-          <div className="mt-5 w-11/12 text-center">
+          <animated.div
+            style={appearAnimProps}
+            className=" w-11/12 text-center"
+          >
             <IonButton className="w-full" onClick={navigateNext}>
               Continue
             </IonButton>
-          </div>
+          </animated.div>
         </div>
       </IonContent>
     </IonPage>

--- a/src/useStore.ts
+++ b/src/useStore.ts
@@ -6,10 +6,19 @@ import { QUESTION_TIME } from './settings'
 
 const { Storage } = Plugins
 
-interface Guess {
+export interface Guess {
   imdbId: string
   title: string
-  posterUrl: string
+  posterPath: string
+}
+
+export interface Movie {
+  imdbId: string
+  title: string
+  posterPath: string
+  budget: number
+  revenue: number
+  popularity: number
 }
 
 interface Store {
@@ -19,12 +28,12 @@ interface Store {
   points: number
   pointDifference: number
   timeRemaining: number
-  movie: Guess
+  movie: Movie
   guess: Guess
   setState: (state: Partial<Store>) => void
   resetState: () => void
   setTimeRemaining: (fun: (currentTime: number) => number) => void
-  setMovie: (data: Guess) => void
+  setMovie: (data: Movie) => void
   setGuess: (data: Guess) => void
   addPoints: (points: number) => void
   setPointDifference: (pointDifference: number) => void
@@ -66,12 +75,15 @@ const initialState: Partial<Store> = {
   movie: {
     imdbId: '',
     title: '',
-    posterUrl: '',
+    posterPath: '',
+    budget: 0,
+    popularity: 0.0,
+    revenue: 0,
   },
   guess: {
     imdbId: '',
     title: '',
-    posterUrl: '',
+    posterPath: '',
   },
 }
 
@@ -94,7 +106,7 @@ const [useStore] = create<Store>(
         })
       },
 
-      setMovie(data: Guess) {
+      setMovie(data: Movie) {
         set((state: Store) => {
           state.movie = data
         })


### PR DESCRIPTION
### Description

This PR extends the existing Trivia screen with some simple animations and more details about the movie such as revenue, budget and popularity.

The movie data is taken from the cache similar how the Question screen gets it's data.

![trivia_animated](https://user-images.githubusercontent.com/22471485/80455657-7a33c180-892c-11ea-824b-20a253cfef44.gif)

### Related Issues

#122 

### Checklist

- [x] Have you added tests where necessary? Do all the test pass? 
- [x] Have you added descriptive comments to your code?
- [x] Have you updated the documentation related to this propo

